### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
   workflow_call:
   workflow_dispatch: 
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
Potential fix for [https://github.com/Caik/go-mock-server/security/code-scanning/7](https://github.com/Caik/go-mock-server/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for accessing the repository's code.
- `contents: write` for steps like `Go Format` and `Go Tidy`, which involve making changes to the repository and verifying them with `git diff`.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
