### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
 env:
   DOCKERHUB_REPO: caik/go-mock-server
 


### PR DESCRIPTION
Potential fix for [https://github.com/Caik/go-mock-server/security/code-scanning/8](https://github.com/Caik/go-mock-server/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are required:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images.
- `pull-requests: write` for creating GitHub releases.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires additional or fewer permissions, we can override the permissions at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
