### PR TITLE
feat: Add CORS support with enable/disable functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Optimize performance and enhance Go Mock Server's reliability, making it more su
 
 Ensure accurate content-type handling by Go Mock Server. The application automatically returns the client's request content-type. In cases where no content-type is passed in the request, the application defaults to `text/plain`, ensuring seamless handling and compatibility with diverse APIs.
 
-### 7. Dynamic Mock Creation
+### 7. CORS Support
+
+Automatically adds Cross-Origin Resource Sharing (CORS) headers to all mock responses, making the mock server compatible with web applications that require CORS. The CORS service can be disabled using the `--disable-cors` flag if not needed.
+
+### 8. Dynamic Mock Creation
 
 Dynamically create mocks on the fly in two convenient ways:
 
@@ -91,11 +95,11 @@ Dynamically create mocks on the fly in two convenient ways:
 
 2. **API Interaction:** Interact with Go Mock Server's API to dynamically create, update, or delete mocks. This provides users with fine-grained control over mock configurations during runtime.
 
-### 8. Dynamic Configuration via API
+### 9. Dynamic Configuration via API
 
 Configure the simulation of errors and latencies dynamically with Go Mock Server's powerful API. This feature empowers users to fine-tune error simulation and adjust latencies for specific hosts and/or URIs during runtime. Gain precise control over the testing environment to ensure comprehensive and targeted evaluations of your application's resilience and performance.
 
-### 9. Cross-Platform Support
+### 10. Cross-Platform Support
 
 Go Mock Server provides precompiled binaries for Linux, Mac (AMD64 and ARM64), and Windows. Choose the binary that suits your platform or build from source if preferred.
 
@@ -306,12 +310,16 @@ To customize Go Mock Server's behavior, you can use the following command-line o
 | --disable-cache         | Disable caching of responses.                              |
 | --disable-latency       | Disable simulation of latency in responses.                |
 | --disable-error         | Disable simulation of error responses.                     |
+| --disable-cors          | Disable CORS headers in responses.                         |
 
 **Example:**
 
 ```bash
 # Run the server on port 9090 with a custom mock directory and disable cache
 ./mock-server_mac --mocks-directory ./custom-mocks --port 9090 --disable-cache
+
+# Run the server with CORS disabled for environments that don't need it
+./mock-server_mac --mocks-directory ./mocks --disable-cors
 ```
 
 <br />

--- a/internal/config/app_arguments.go
+++ b/internal/config/app_arguments.go
@@ -7,4 +7,5 @@ type AppArguments struct {
 	DisableCache    bool   `arg:"--disable-cache" help:"disable the caching"`
 	DisableLatency  bool   `arg:"--disable-latency" help:"disable latency simulation"`
 	DisableError    bool   `arg:"--disable-error" help:"disable error simulation"`
+	DisableCors     bool   `arg:"--disable-cors" help:"disable CORS headers"`
 }

--- a/internal/server/controller/mocks_controller.go
+++ b/internal/server/controller/mocks_controller.go
@@ -33,6 +33,13 @@ func (m *MocksController) handleMockRequest(c *gin.Context) {
 		}
 	}
 
+	// Set additional headers if present
+	if mockResponse.Headers != nil {
+		for key, value := range *mockResponse.Headers {
+			c.Header(key, value)
+		}
+	}
+
 	c.Data(mockResponse.StatusCode, mockResponse.ContentType, *mockResponse.Data)
 }
 

--- a/internal/service/mock/cors_mock_service.go
+++ b/internal/service/mock/cors_mock_service.go
@@ -1,0 +1,52 @@
+package mock
+
+import (
+	"github.com/rs/zerolog/log"
+)
+
+type corsMockService struct {
+	next mockService
+}
+
+func (c *corsMockService) getMockResponse(mockRequest MockRequest) *MockResponse {
+	mockResponse := c.nextOrNil(mockRequest)
+
+	if mockResponse == nil {
+		return nil
+	}
+
+	// Add CORS headers to the response
+	corsHeaders := c.getCorsHeaders()
+	mockResponse.AddHeaders(corsHeaders)
+
+	log.Info().
+		Str("uuid", mockRequest.Uuid).
+		Msg("adding CORS headers")
+
+	return mockResponse
+}
+
+func (c *corsMockService) setNext(next mockService) {
+	c.next = next
+}
+
+func (c *corsMockService) nextOrNil(mockRequest MockRequest) *MockResponse {
+	if c.next == nil {
+		return nil
+	}
+
+	return c.next.getMockResponse(mockRequest)
+}
+
+func (c *corsMockService) getCorsHeaders() map[string]string {
+	return map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD",
+		"Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With, Accept, Origin",
+		"Access-Control-Max-Age":       "86400",
+	}
+}
+
+func newCorsMockService() *corsMockService {
+	return &corsMockService{}
+}

--- a/internal/service/mock/cors_mock_service_test.go
+++ b/internal/service/mock/cors_mock_service_test.go
@@ -1,0 +1,198 @@
+package mock
+
+import (
+	"testing"
+)
+
+func TestCorsMockService_GetMockResponse(t *testing.T) {
+	t.Run("adds CORS headers when response has no existing headers", func(t *testing.T) {
+		// Create a mock service that returns a response without headers
+		testData := []byte("test response")
+		mockNext := &mockMockService{
+			response: &MockResponse{
+				StatusCode:  200,
+				Data:        &testData,
+				ContentType: "application/json",
+				Headers:     nil,
+			},
+		}
+
+		corsService := newCorsMockService()
+		corsService.setNext(mockNext)
+
+		request := MockRequest{
+			Host:   "example.com",
+			Method: "GET",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		response := corsService.getMockResponse(request)
+
+		// Verify response is not nil
+		if response == nil {
+			t.Fatal("expected response, got nil")
+		}
+
+		// Verify headers were added
+		if response.Headers == nil {
+			t.Fatal("expected headers to be set, got nil")
+		}
+
+		expectedHeaders := map[string]string{
+			"Access-Control-Allow-Origin":  "*",
+			"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD",
+			"Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With, Accept, Origin",
+			"Access-Control-Max-Age":       "86400",
+		}
+
+		for key, expectedValue := range expectedHeaders {
+			if actualValue, exists := (*response.Headers)[key]; !exists {
+				t.Errorf("expected header %s to be set", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("expected header %s to be %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+
+		// Verify original response data is preserved
+		if response.StatusCode != 200 {
+			t.Errorf("expected status code 200, got %d", response.StatusCode)
+		}
+		if response.ContentType != "application/json" {
+			t.Errorf("expected content type application/json, got %s", response.ContentType)
+		}
+	})
+
+	t.Run("merges CORS headers with existing headers", func(t *testing.T) {
+		// Create a mock service that returns a response with existing headers
+		testData := []byte("test response")
+		existingHeaders := map[string]string{
+			"X-Custom-Header": "custom-value",
+			"Cache-Control":   "no-cache",
+		}
+		mockNext := &mockMockService{
+			response: &MockResponse{
+				StatusCode:  200,
+				Data:        &testData,
+				ContentType: "application/json",
+				Headers:     &existingHeaders,
+			},
+		}
+
+		corsService := newCorsMockService()
+		corsService.setNext(mockNext)
+
+		request := MockRequest{
+			Host:   "example.com",
+			Method: "POST",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		response := corsService.getMockResponse(request)
+
+		// Verify response is not nil
+		if response == nil {
+			t.Fatal("expected response, got nil")
+		}
+
+		// Verify headers were merged
+		if response.Headers == nil {
+			t.Fatal("expected headers to be set, got nil")
+		}
+
+		// Check that existing headers are preserved
+		if (*response.Headers)["X-Custom-Header"] != "custom-value" {
+			t.Error("expected existing custom header to be preserved")
+		}
+		if (*response.Headers)["Cache-Control"] != "no-cache" {
+			t.Error("expected existing cache-control header to be preserved")
+		}
+
+		// Check that CORS headers were added
+		expectedCorsHeaders := map[string]string{
+			"Access-Control-Allow-Origin":  "*",
+			"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD",
+			"Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With, Accept, Origin",
+			"Access-Control-Max-Age":       "86400",
+		}
+
+		for key, expectedValue := range expectedCorsHeaders {
+			if actualValue, exists := (*response.Headers)[key]; !exists {
+				t.Errorf("expected CORS header %s to be set", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("expected CORS header %s to be %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+	})
+
+	t.Run("returns nil when next service returns nil", func(t *testing.T) {
+		mockNext := &mockMockService{
+			response: nil,
+		}
+
+		corsService := newCorsMockService()
+		corsService.setNext(mockNext)
+
+		request := MockRequest{
+			Host:   "example.com",
+			Method: "GET",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		response := corsService.getMockResponse(request)
+
+		if response != nil {
+			t.Error("expected nil response when next service returns nil")
+		}
+	})
+
+	t.Run("returns nil when no next service is set", func(t *testing.T) {
+		corsService := newCorsMockService()
+		// Don't set next service
+
+		request := MockRequest{
+			Host:   "example.com",
+			Method: "GET",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		response := corsService.getMockResponse(request)
+
+		if response != nil {
+			t.Error("expected nil response when no next service is set")
+		}
+	})
+}
+
+func TestCorsMockService_GetCorsHeaders(t *testing.T) {
+	corsService := newCorsMockService()
+	headers := corsService.getCorsHeaders()
+
+	expectedHeaders := map[string]string{
+		"Access-Control-Allow-Origin":  "*",
+		"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD",
+		"Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With, Accept, Origin",
+		"Access-Control-Max-Age":       "86400",
+	}
+
+	if len(headers) != len(expectedHeaders) {
+		t.Errorf("expected %d headers, got %d", len(expectedHeaders), len(headers))
+	}
+
+	for key, expectedValue := range expectedHeaders {
+		if actualValue, exists := headers[key]; !exists {
+			t.Errorf("expected header %s to be present", key)
+		} else if actualValue != expectedValue {
+			t.Errorf("expected header %s to be %s, got %s", key, expectedValue, actualValue)
+		}
+	}
+}
+
+// Note: Using mockMockService from host_resolution_mock_service_test.go

--- a/internal/service/mock/mock_factory_test.go
+++ b/internal/service/mock/mock_factory_test.go
@@ -25,6 +25,9 @@ func (m *mockCacheService) Get(key, uuid string) (*[]byte, bool) {
 }
 
 func (m *mockCacheService) Set(key string, data *[]byte, uuid string) {
+	if m.cache == nil {
+		m.cache = make(map[string][]byte)
+	}
 	m.cache[key] = *data
 }
 
@@ -44,6 +47,7 @@ func TestNewMockServiceFactory(t *testing.T) {
 			DisableLatency: false,
 			DisableError:   false,
 			DisableCache:   false,
+			DisableCors:    false,
 		}
 
 		factory := NewMockServiceFactory(contentService, cacheService, appArgs, hostsConfig)
@@ -72,6 +76,7 @@ func TestNewMockServiceFactory(t *testing.T) {
 			DisableLatency: true, // Disabled
 			DisableError:   false,
 			DisableCache:   false,
+			DisableCors:    false,
 		}
 
 		factory := NewMockServiceFactory(contentService, cacheService, appArgs, hostsConfig)
@@ -112,6 +117,7 @@ func TestNewMockServiceFactory(t *testing.T) {
 			DisableLatency: true,
 			DisableError:   false,
 			DisableCache:   false,
+			DisableCors:    false,
 		}
 
 		factory1 := NewMockServiceFactory(contentService, cacheService, appArgs1, hostsConfig)
@@ -121,6 +127,7 @@ func TestNewMockServiceFactory(t *testing.T) {
 			DisableLatency: false,
 			DisableError:   false,
 			DisableCache:   true,
+			DisableCors:    false,
 		}
 
 		factory2 := NewMockServiceFactory(contentService, cacheService, appArgs2, hostsConfig)
@@ -130,17 +137,118 @@ func TestNewMockServiceFactory(t *testing.T) {
 			DisableLatency: true,
 			DisableError:   false,
 			DisableCache:   true,
+			DisableCors:    false,
 		}
 
 		factory3 := NewMockServiceFactory(contentService, cacheService, appArgs3, hostsConfig)
 
+		// Test case 4: DisableCors=true should disable CORS service
+		appArgs4 := &config.AppArguments{
+			DisableLatency: false,
+			DisableError:   false,
+			DisableCache:   false,
+			DisableCors:    true,
+		}
+
+		factory4 := NewMockServiceFactory(contentService, cacheService, appArgs4, hostsConfig)
+
 		// All factories should be created successfully
-		if factory1 == nil || factory2 == nil || factory3 == nil {
+		if factory1 == nil || factory2 == nil || factory3 == nil || factory4 == nil {
 			t.Error("all factories should be created successfully")
 		}
 
-		t.Log("disable flags work correctly for latency and cache services")
+		t.Log("disable flags work correctly for latency, cache, and CORS services")
 		t.Log("factory creation successful with various disable flag combinations")
+	})
+}
+
+func TestMockServiceFactory_DisableCorsFlag(t *testing.T) {
+	t.Run("CORS service behavior with disable flag", func(t *testing.T) {
+		contentService := &mockContentService{
+			contents: make(map[string][]byte),
+			events:   make(chan content.ContentEvent),
+		}
+		cacheService := &mockCacheService{
+			cache: make(map[string][]byte),
+		}
+		hostsConfig := &config.HostsConfig{}
+
+		// Add some test content so the service chain doesn't fail
+		testData := []byte(`{"message": "test"}`)
+		contentService.contents["example.com/api/test.get"] = testData
+
+		// Test case 1: CORS enabled (default)
+		appArgsEnabled := &config.AppArguments{
+			DisableLatency: true,  // Disable to simplify test
+			DisableError:   true,  // Disable to simplify test
+			DisableCache:   true,  // Disable to simplify test
+			DisableCors:    false, // CORS enabled
+		}
+
+		factoryEnabled := NewMockServiceFactory(contentService, cacheService, appArgsEnabled, hostsConfig)
+
+		// Test case 2: CORS disabled
+		appArgsDisabled := &config.AppArguments{
+			DisableLatency: true, // Disable to simplify test
+			DisableError:   true, // Disable to simplify test
+			DisableCache:   true, // Disable to simplify test
+			DisableCors:    true, // CORS disabled
+		}
+
+		factoryDisabled := NewMockServiceFactory(contentService, cacheService, appArgsDisabled, hostsConfig)
+
+		// Create a test request
+		testRequest := MockRequest{
+			Host:   "example.com",
+			Method: "GET",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		// Test with CORS enabled - should have CORS headers
+		responseEnabled := factoryEnabled.GetMockResponse(testRequest)
+		if responseEnabled != nil && responseEnabled.Headers != nil {
+			corsHeaders := []string{
+				"Access-Control-Allow-Origin",
+				"Access-Control-Allow-Methods",
+				"Access-Control-Allow-Headers",
+				"Access-Control-Max-Age",
+			}
+
+			for _, header := range corsHeaders {
+				if _, exists := (*responseEnabled.Headers)[header]; !exists {
+					t.Errorf("Expected CORS header %s to be present when CORS is enabled", header)
+				}
+			}
+			t.Log("CORS headers correctly added when CORS is enabled")
+		} else {
+			t.Error("Expected response with headers when CORS is enabled")
+		}
+
+		// Test with CORS disabled - should not have CORS headers
+		responseDisabled := factoryDisabled.GetMockResponse(testRequest)
+		if responseDisabled != nil {
+			if responseDisabled.Headers != nil {
+				corsHeaders := []string{
+					"Access-Control-Allow-Origin",
+					"Access-Control-Allow-Methods",
+					"Access-Control-Allow-Headers",
+					"Access-Control-Max-Age",
+				}
+
+				for _, header := range corsHeaders {
+					if _, exists := (*responseDisabled.Headers)[header]; exists {
+						t.Errorf("Expected CORS header %s to NOT be present when CORS is disabled", header)
+					}
+				}
+			}
+			t.Log("CORS headers correctly omitted when CORS is disabled")
+		} else {
+			t.Error("Expected response when CORS is disabled")
+		}
+
+		t.Log("CORS disable flag works correctly")
 	})
 }
 
@@ -162,6 +270,7 @@ func TestMockServiceFactory_GetMockResponse(t *testing.T) {
 			DisableLatency: false,
 			DisableError:   false,
 			DisableCache:   false,
+			DisableCors:    false,
 		}
 
 		factory := NewMockServiceFactory(contentService, cacheService, appArgs, hostsConfig)
@@ -204,10 +313,10 @@ func TestMockServiceFactory_initServiceChain(t *testing.T) {
 		factory := &MockServiceFactory{}
 
 		// Call initServiceChain multiple times
-		factory.initServiceChain(contentService, cacheService, false, false, false, hostsConfig)
+		factory.initServiceChain(contentService, cacheService, false, false, false, false, hostsConfig)
 		firstChain := factory.mockServiceChain
 
-		factory.initServiceChain(contentService, cacheService, false, false, false, hostsConfig)
+		factory.initServiceChain(contentService, cacheService, false, false, false, false, hostsConfig)
 		secondChain := factory.mockServiceChain
 
 		// Should be the same instance (sync.Once behavior)

--- a/internal/service/mock/mock_service.go
+++ b/internal/service/mock/mock_service.go
@@ -22,8 +22,21 @@ type MockResponse struct {
 	StatusCode          int
 	Data                *[]byte
 	ContentType         string
+	Headers             *map[string]string
 	activeErrorConfig   *config.ErrorConfig
 	activeLatencyConfig *config.LatencyConfig
+}
+
+// AddHeaders adds the provided headers to the MockResponse, merging with existing headers if present
+func (m *MockResponse) AddHeaders(headers map[string]string) {
+	if m.Headers == nil {
+		m.Headers = &headers
+	} else {
+		// Merge headers with existing ones
+		for key, value := range headers {
+			(*m.Headers)[key] = value
+		}
+	}
 }
 
 func GenerateCacheKey(mockRequest MockRequest) string {

--- a/internal/service/mock/mock_service_test.go
+++ b/internal/service/mock/mock_service_test.go
@@ -1,0 +1,167 @@
+package mock
+
+import (
+	"testing"
+)
+
+func TestMockResponse_AddHeaders(t *testing.T) {
+	t.Run("adds headers when none exist", func(t *testing.T) {
+		response := &MockResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Headers:     nil,
+		}
+
+		headersToAdd := map[string]string{
+			"X-Custom-Header": "custom-value",
+			"Cache-Control":   "no-cache",
+		}
+
+		response.AddHeaders(headersToAdd)
+
+		if response.Headers == nil {
+			t.Fatal("expected headers to be set, got nil")
+		}
+
+		for key, expectedValue := range headersToAdd {
+			if actualValue, exists := (*response.Headers)[key]; !exists {
+				t.Errorf("expected header %s to be set", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("expected header %s to be %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+	})
+
+	t.Run("merges headers with existing ones", func(t *testing.T) {
+		existingHeaders := map[string]string{
+			"Content-Encoding": "gzip",
+			"X-Existing":       "existing-value",
+		}
+
+		response := &MockResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Headers:     &existingHeaders,
+		}
+
+		headersToAdd := map[string]string{
+			"X-Custom-Header": "custom-value",
+			"Cache-Control":   "no-cache",
+		}
+
+		response.AddHeaders(headersToAdd)
+
+		if response.Headers == nil {
+			t.Fatal("expected headers to be set, got nil")
+		}
+
+		// Check existing headers are preserved
+		if (*response.Headers)["Content-Encoding"] != "gzip" {
+			t.Error("expected existing header Content-Encoding to be preserved")
+		}
+		if (*response.Headers)["X-Existing"] != "existing-value" {
+			t.Error("expected existing header X-Existing to be preserved")
+		}
+
+		// Check new headers are added
+		for key, expectedValue := range headersToAdd {
+			if actualValue, exists := (*response.Headers)[key]; !exists {
+				t.Errorf("expected header %s to be set", key)
+			} else if actualValue != expectedValue {
+				t.Errorf("expected header %s to be %s, got %s", key, expectedValue, actualValue)
+			}
+		}
+	})
+
+	t.Run("overwrites existing headers with same key", func(t *testing.T) {
+		existingHeaders := map[string]string{
+			"X-Custom-Header": "old-value",
+			"Cache-Control":   "max-age=3600",
+		}
+
+		response := &MockResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Headers:     &existingHeaders,
+		}
+
+		headersToAdd := map[string]string{
+			"X-Custom-Header": "new-value",
+			"X-New-Header":    "new-header-value",
+		}
+
+		response.AddHeaders(headersToAdd)
+
+		if response.Headers == nil {
+			t.Fatal("expected headers to be set, got nil")
+		}
+
+		// Check that existing header was overwritten
+		if (*response.Headers)["X-Custom-Header"] != "new-value" {
+			t.Errorf("expected X-Custom-Header to be overwritten with new-value, got %s", (*response.Headers)["X-Custom-Header"])
+		}
+
+		// Check that other existing header is preserved
+		if (*response.Headers)["Cache-Control"] != "max-age=3600" {
+			t.Error("expected existing Cache-Control header to be preserved")
+		}
+
+		// Check that new header is added
+		if (*response.Headers)["X-New-Header"] != "new-header-value" {
+			t.Error("expected new header X-New-Header to be added")
+		}
+	})
+
+	t.Run("handles empty headers map", func(t *testing.T) {
+		response := &MockResponse{
+			StatusCode:  200,
+			ContentType: "application/json",
+			Headers:     nil,
+		}
+
+		emptyHeaders := map[string]string{}
+		response.AddHeaders(emptyHeaders)
+
+		if response.Headers == nil {
+			t.Error("expected headers to be initialized even with empty map")
+		}
+
+		if len(*response.Headers) != 0 {
+			t.Errorf("expected empty headers map, got %d headers", len(*response.Headers))
+		}
+	})
+}
+
+func TestGenerateCacheKey(t *testing.T) {
+	t.Run("generates correct cache key", func(t *testing.T) {
+		request := MockRequest{
+			Host:   "example.com",
+			Method: "GET",
+			URI:    "/api/test",
+			Accept: "application/json",
+			Uuid:   "test-uuid",
+		}
+
+		key := GenerateCacheKey(request)
+		expected := "example.com:GET:/api/test"
+
+		if key != expected {
+			t.Errorf("expected cache key %s, got %s", expected, key)
+		}
+	})
+
+	t.Run("handles empty values", func(t *testing.T) {
+		request := MockRequest{
+			Host:   "",
+			Method: "",
+			URI:    "",
+		}
+
+		key := GenerateCacheKey(request)
+		expected := "::"
+
+		if key != expected {
+			t.Errorf("expected cache key %s, got %s", expected, key)
+		}
+	})
+}


### PR DESCRIPTION
- Add CORS mock service that automatically adds CORS headers to responses
- Implement --disable-cors flag to optionally disable CORS functionality
- Add Headers field to MockResponse struct for additional HTTP headers
- Add AddHeaders method to MockResponse for clean header management
- Update controller to set headers from MockResponse
- Integrate CORS service into service chain after host resolution
- Add comprehensive tests for CORS functionality and disable flag
- Update README.md with CORS feature documentation and usage examples

CORS Headers added:
- Access-Control-Allow-Origin: *
- Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD
- Access-Control-Allow-Headers: Content-Type, Authorization, X-Requested-With, Accept, Origin
- Access-Control-Max-Age: 86400

The CORS service follows the same enable/disable pattern as other services and is enabled by default for web application compatibility.